### PR TITLE
[QR Portal] feat: add GraphQL filter for active employees in fetchAllEmployees

### DIFF
--- a/apps/qr-portal/backend/modules/people/people.bal
+++ b/apps/qr-portal/backend/modules/people/people.bal
@@ -52,6 +52,10 @@ public isolated function fetchAllEmployees() returns EmployeeBase[]|error {
         }
     `;
 
+    GraphQLEmployeeFilter filter = {
+        isActive: true
+    };
+
     EmployeeBase[] employees = [];
     boolean fetchMore = true;
     int offset = 0;
@@ -60,7 +64,7 @@ public isolated function fetchAllEmployees() returns EmployeeBase[]|error {
     while fetchMore {
         MultipleEmployeesResponse response = check hrClient->execute(
             document,
-            {filter: {}, 'limit: defaultLimit, offset: offset}
+            {filter: filter, 'limit: defaultLimit, offset: offset}
         );
         EmployeeBase[] batch = response.data.employees;
         employees.push(...batch);

--- a/apps/qr-portal/backend/modules/people/types.bal
+++ b/apps/qr-portal/backend/modules/people/types.bal
@@ -66,6 +66,12 @@ type SingleEmployeeResponse record {|
     |} data;
 |};
 
+# GraphQL Employee filter record.
+type GraphQLEmployeeFilter record {|
+    # Employee is active or not
+    boolean isActive = true;
+|};
+
 # GraphQL multiple employees response.
 type MultipleEmployeesResponse record {|
     # Response data wrapper


### PR DESCRIPTION
This pull request updates the employee fetching logic to ensure only active employees are retrieved from the HR system. The main changes include introducing a new filter type and applying it to the GraphQL query.

**Employee filtering improvements:**

* Introduced a new `GraphQLEmployeeFilter` record type in `types.bal` to specify employee activity status in GraphQL queries.
* Created a `filter` variable with `isActive: true` in `fetchAllEmployees()` to fetch only active employees.
* Updated the call to the HR client in `fetchAllEmployees()` to use the new `filter` instead of an empty filter object.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated employee list retrieval to display only active employees in the system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->