### PR TITLE
[O2C Portal Backend] Remove authorisation check from GET qr-code/{id}

### DIFF
--- a/apps/o2c-portal/backend/README.md
+++ b/apps/o2c-portal/backend/README.md
@@ -144,7 +144,7 @@
 
 **Summary:** Fetch a specific QR code by its UUID.
 
-**Authorization:** Requires Con Attendee Role
+**Authorization:** None required (public endpoint)
 
 **Parameters:**
 
@@ -157,7 +157,6 @@
 | Status | Description         | Schema                        |
 | ------ | ------------------- | ----------------------------- |
 | 200    | OK                  | [ConferenceQrCode](#conferenceqrcode) |
-| 403    | Forbidden           | -                             |
 | 404    | NotFound            | -                             |
 | 500    | InternalServerError | -                             |
 

--- a/apps/o2c-portal/backend/modules/authorization/authorization.bal
+++ b/apps/o2c-portal/backend/modules/authorization/authorization.bal
@@ -27,6 +27,11 @@ public isolated service class JwtInterceptor {
     isolated resource function default [string... path](http:RequestContext ctx, http:Request req)
         returns http:NextService|http:Forbidden|http:Unauthorized|error? {
         
+        // For public endpoints that bypass authorization: GET /qr-codes/{id}
+        if req.method == http:GET && path.length() == 2 && path[0] == PATH_QR_CODES  {
+            return ctx.next();
+        }
+
         string|error idToken = req.getHeader(JWT_ASSERTION_HEADER);
         if idToken is error {
             string errorMsg = "Missing invoker info header!";

--- a/apps/o2c-portal/backend/service.bal
+++ b/apps/o2c-portal/backend/service.bal
@@ -349,21 +349,10 @@ service http:InterceptableService / on new http:Listener(9090) {
 
     # Fetch a specific QR by ID.
     #
-    # + ctx - Request context
     # + id - UUID of the QR code
     # + return - QR details or error
-    resource function get qr\-codes/[string id](http:RequestContext ctx)
-        returns database:ConferenceQrCode|http:NotFound|http:Forbidden|http:InternalServerError {
-
-        authorization:CustomJwtPayload|error userInfo = ctx.getWithType(authorization:HEADER_USER_INFO);
-        if userInfo is error {
-            log:printError(USER_INFO_HEADER_NOT_FOUND_ERROR, userInfo);
-            return <http:InternalServerError>{
-                body: {
-                    message: USER_INFO_HEADER_NOT_FOUND_ERROR
-                }
-            };
-        }
+    resource function get qr\-codes/[string id]()
+        returns database:ConferenceQrCode|http:NotFound|http:InternalServerError {
 
         database:ConferenceQrCode|error? qr = database:fetchConferenceQrCode(id);
         if qr is error {


### PR DESCRIPTION
This pull request updates the QR code fetching endpoint in the O2C portal backend to make it publicly accessible, removing the previous authorization requirement. The changes affect documentation, authorization logic, and the service implementation.

**Public access to QR code endpoint:**

* Updated `README.md` to indicate that fetching a specific QR code by UUID no longer requires authorization and removed the 403 Forbidden response from the documented responses. [[1]](diffhunk://#diff-9ec65e2b1ea72b9aa4ec013a61863018d16ebceeffb204eea0c55bb6b6ec88b1L147-R147) [[2]](diffhunk://#diff-9ec65e2b1ea72b9aa4ec013a61863018d16ebceeffb204eea0c55bb6b6ec88b1L160)

**Authorization bypass logic:**

* Modified `JwtInterceptor` in `authorization.bal` to bypass authorization checks for GET requests to `/qr-codes/{id}` by allowing such requests to proceed without validating JWT headers.

**Endpoint implementation changes:**

* Updated the QR code fetching resource function in `service.bal` to remove user info extraction and error handling related to authorization, reflecting its new public status. The endpoint now returns either the QR code details or relevant error responses.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The QR code retrieval endpoint (`GET /qr-codes/{id}`) is now publicly accessible without authentication.

* **Documentation**
  * Updated API documentation to reflect public access requirements for the QR code endpoint.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/wso2-open-operations/wso2-coin/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->